### PR TITLE
Introduce appropriate automatic pagination

### DIFF
--- a/pockyt/client.py
+++ b/pockyt/client.py
@@ -125,7 +125,6 @@ class Client(object):
             "detailType": "complete",
             "total": "1",            
         }
-        print(payload)
         if self._args.content != "all":
             payload["contentType"] = self._args.content
 


### PR DESCRIPTION
The [V3 API](https://getpocket.com/developer/docs/v3/retrieve) of pocket states that retrieved results are paginated.

> The maximum page size limit is 30 results. In order to retrieve more, you must paginate the result set.

The codebase does not deal with this situation and hence the `--count` argument fails when:

- count > 30
- count = -1

In both cases the result set will be limited to 30 items or less. What should happen is as stated in the pockyt documentation:

> number of items : : {-1: all, [n: amount]}

This PR fixes the issue by retrieving all items or the correct count of items as specified and not just the 30 provided in the first page of the pocket API response.